### PR TITLE
Make script safer by adding safeguards

### DIFF
--- a/mc-to-mt-tp-conv/conv.sh
+++ b/mc-to-mt-tp-conv/conv.sh
@@ -10,33 +10,24 @@ mkdir b
 mkdir i
 cd .. || exit 1
 
-
-FILES="$(dirname "$0")/../assets/minecraft/textures/blocks/*.png"
-for f in $FILES
-do
-	cp "$f" "uctextures/b/"
+for f in "$(dirname "$0")/../assets/minecraft/textures/blocks/"*.png; do
+	cp -- "$f" "uctextures/b/"
 done
-
-FILES="$(dirname "$0")/../assets/minecraft/textures/items/*.png"
-for f in $FILES
-do
-	cp "$f" "uctextures/i/"
+for f in "$(dirname "$0")/../assets/minecraft/textures/items/"*.png; do
+	cp -- "$f" "uctextures/i/"
 done
 
 cd uctextures || exit 1
 
 while read -r p; do
-	if [ -n "$p" ]
-	then
-		if [ -e "trans.png" ]
-		then
+	if [ -n "$p" ]; then
+		if [ -e "trans.png" ]; then
 			mv trans.png "../textures/$p"
 		else
-			mv "$p" trans.png
+			mv -- "$p" trans.png
 		fi
 	fi
-done < ../mc-to-mt-tp-conv/transtable.txt
-
+done <../mc-to-mt-tp-conv/transtable.txt
 
 #####################################
 convert "b/destroy_stage_0.png" \
@@ -49,7 +40,7 @@ convert "b/destroy_stage_0.png" \
 	"b/destroy_stage_7.png" \
 	"b/destroy_stage_8.png" \
 	"b/destroy_stage_9.png" \
-			+append "../textures/crack-anylength.png"
+	+append "../textures/crack-anylength.png"
 #####################################
 
 cd ..

--- a/mc-to-mt-tp-conv/conv.sh
+++ b/mc-to-mt-tp-conv/conv.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
-cd "$(dirname "$0")"
-cd ..
+cd -- "$(dirname "$0")" || exit 1
+cd .. || exit 1
 rm -rf minetest-texture-pack
 rm -rf uctextures
 mkdir textures
 mkdir uctextures
-cd uctextures
+cd uctextures || exit 1
 mkdir b
 mkdir i
-cd ..
+cd .. || exit 1
 
 
-FILES=$(dirname "$0")/../assets/minecraft/textures/blocks/*.png
+FILES="$(dirname "$0")/../assets/minecraft/textures/blocks/*.png"
 for f in $FILES
 do
-	cp $f "uctextures/b/"
+	cp "$f" "uctextures/b/"
 done
 
-FILES=$(dirname "$0")/../assets/minecraft/textures/items/*.png
+FILES="$(dirname "$0")/../assets/minecraft/textures/items/*.png"
 for f in $FILES
 do
-	cp $f "uctextures/i/"
+	cp "$f" "uctextures/i/"
 done
 
-cd uctextures
+cd uctextures || exit 1
 
-while read p; do
+while read -r p; do
 	if [ -n "$p" ]
 	then
 		if [ -e "trans.png" ]


### PR DESCRIPTION
Adds quotes to prevent accidental globs, adds `|| exit ` to `cd`s to exit if they fail, adds `-r` to `read`